### PR TITLE
Task 2 - Add Docker support with Dockerfile, docker-compose, and dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+npm-debug.log
+.env

--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,3 @@
-DATABASE_URL="mysql://root:@localhost:3306/contact_mananager"
+DATABASE_URL="mysql://root:root@localhost:3306/contact_manager"
 JWT_SECRET="your_jwt_secret"
 JWT_EXPIRATION_TIME="3600"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+# node image
+FROM node:20
+
+# working directory
+WORKDIR /app
+
+# dependencies
+COPY package*.json ./
+RUN npm install
+
+# copy application files
+COPY . .
+
+# expose the API port
+EXPOSE 3000
+
+# command to start the server
+CMD ["npm", "run", "dev"]

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The **Contact Manager API** allows users to authenticate and manage their contac
 - **Node.js** version 18 or higher.
 - **MySQL** for the database (or any compatible database with Prisma).
 
-## Installation
+## Installation 
 
 1. Clone the repository:
    ```bash
@@ -29,7 +29,7 @@ The **Contact Manager API** allows users to authenticate and manage their contac
 
    Example:
    ```
-   DATABASE_URL="mysql://root:@localhost:3306/contact_manager"
+   DATABASE_URL="mysql://root:root@localhost:3306/contact_manager"
    JWT_SECRET="your_jwt_secret"
    JWT_EXPIRATION_TIME="3600"
    ```
@@ -53,10 +53,56 @@ The **Contact Manager API** allows users to authenticate and manage their contac
 
 ## Testing
 
-1. Run the script:
+- Run the script:
    ```bash
    npm run test
    ```
+   
+## Docker Setup
+
+If you prefer to use docker, the project includes a `docker-compose.yml` file that will set up both the API and the MySQL database, run the migrations and start the server, the API will be available at http://localhost:3000.
+
+1. Set up environment variables. Create a `.env` file from the `.env.example` file:
+   ```bash
+   cp .env.example .env
+   ```
+
+   Then, fill in the database connection and JWT secret details. Make sure the database name and MySQL password match the ones in the `docker-compose.yml` file.
+
+   Example:
+   ```
+   DATABASE_URL="mysql://root:root@localhost:3306/contact_manager"
+   JWT_SECRET="your_jwt_secret"
+   JWT_EXPIRATION_TIME="3600"
+   ```
+
+  2. Run the command to build, start the containers and the api server:
+   ```bash
+   docker-compose up --build
+   ```
+
+
+### Docker Commands
+
+- **Build and start the containers**:
+  ```bash
+  docker-compose up --build
+  ```
+
+- **Stop the containers**:
+  ```bash
+  docker-compose down
+  ```
+
+- **View logs**:
+  ```bash
+  docker-compose logs
+  ```
+
+- **Run API tests**
+  ```bash
+  docker-compose exec api npm run test
+  ```
 
 ## API Routes Documentation
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,34 @@
+services:
+  api:
+    build:
+      context: .
+    environment:
+      - DATABASE_URL=mysql://root:root@db:3306/contact_manager
+      - JWT_SECRET=${JWT_SECRET}
+      - JWT_EXPIRATION_TIME=${JWT_EXPIRATION_TIME}
+    volumes:
+      - .:/app
+    depends_on:
+      db:
+        condition: service_healthy
+    command: sh -c "npx prisma migrate deploy && npm run dev"
+    ports:
+      - "3000:3000"
+
+  db:
+    image: mysql:8
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: contact_manager
+    ports:
+      - "3306:3306"
+    volumes:
+      - db-data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD-SHELL", "mysql -uroot -proot -e 'SELECT 1'"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+
+volumes:
+  db-data:

--- a/package.json
+++ b/package.json
@@ -6,9 +6,7 @@
     "test": "jest",
     "start": "node dist/infrastructure/http/server.js",
     "dev": "tsc-watch --onSuccess \"node dist/infrastructure/http/server.js\"",
-    "build": "tsc",
-    "runbuild": "npm run build",
-    "postinstall": "prisma generate && npm run runbuild"
+    "build": "tsc"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
This PR introduces Docker support to the project by adding the following files:
- `Dockerfile`: Configures the environment for the API.
- `docker-compose.yml`: Defines the services (API and MySQL) and automates container management.
- `.dockerignore`: Excludes unnecessary files from being included in the Docker image.

With these changes, you can now easily set up the project environment using Docker. The API will be available at http://localhost:3000, and the database will be configured as defined in the `docker-compose.yml` file.

To get started, create a `.env` file from the `.env.example`, set up the necessary environment variables, and run `docker-compose up --build` to start the application.
